### PR TITLE
adds check to disable coloAdmin creation for 'our' countries

### DIFF
--- a/AnnexColonialAdmin/common/scripted_buttons/00_colonial_administration_buttons.txt
+++ b/AnnexColonialAdmin/common/scripted_buttons/00_colonial_administration_buttons.txt
@@ -1,0 +1,1142 @@
+﻿je_colonial_administration_button_senegal = {
+	name = "je_colonial_administration_button_senegal"
+	desc = "je_colonial_administration_button_senegal_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_scope_state = {
+			region = sr:region_senegal
+		}
+		NOT = {
+			any_subject_or_below = {
+				has_variable = senegal_subject_var
+			}
+		}
+	}
+
+	possible = {
+		any_scope_state = {
+			region = sr:region_senegal
+			is_largest_state_in_region = yes
+			count >= 2
+		}
+		custom_tooltip = {
+			text = colonial_administration_cooldown
+			NOT = {
+				any_subject_or_below = {
+					has_variable = newly_formed_colonial_nation_var
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+		modifier = {
+			trigger = {
+				spansen_one_of_us = yes
+			}
+			add = -100
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_senegal
+					has_decree = decree_greener_grass_campaign
+				}
+			}
+			random_scope_state = {
+				limit = {
+					region = sr:region_senegal
+					has_decree = decree_greener_grass_campaign
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		else = {
+			random_scope_state = {
+				limit = {
+					region = sr:region_senegal
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		every_scope_state = {
+			limit = {
+				region = sr:region_senegal
+			}
+			set_variable = state_to_cede
+		}
+		create_dynamic_country = {
+			origin = root
+			country_type = colonial
+			tier = principality
+			capital = scope:newly_formed_colonial_nation_capital_scope
+			cede_state_trigger = {
+				has_variable = state_to_cede
+			}
+			on_created = { 
+				set_variable = senegal_subject_var
+				set_variable = {
+					name = newly_formed_colonial_nation_var
+					months = 3
+				}
+				every_scope_state = {
+					remove_variable = state_to_cede
+				}
+				activate_law = law_type:law_frontier_colonization
+				activate_law = law_type:law_presidential_republic
+			}
+		}
+		hidden_effect = {
+			create_diplomatic_pact = {
+				country = scope:newly_formed_colonial_nation_capital_scope.owner
+				type = puppet
+			}
+		}
+		trigger_event = { id = colonial_administration_events.1 days = 1 popup = yes }
+		custom_tooltip = je_colonial_administration_button_tt_1
+		custom_tooltip = je_colonial_administration_button_tt_2
+	}
+}
+
+je_colonial_administration_button_niger = {
+	name = "je_colonial_administration_button_niger"
+	desc = "je_colonial_administration_button_niger_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_scope_state = {
+			region = sr:region_niger
+		}
+		NOT = {
+			any_subject_or_below = {
+				has_variable = niger_subject_var
+			}
+		}
+	}
+
+	possible = {
+		any_scope_state = {
+			region = sr:region_niger
+			is_largest_state_in_region = yes
+			count >= 2
+		}
+		custom_tooltip = {
+			text = colonial_administration_cooldown
+			NOT = {
+				any_subject_or_below = {
+					has_variable = newly_formed_colonial_nation_var
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+		modifier = {
+			trigger = {
+				spansen_one_of_us = yes
+			}
+			add = -100
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_niger
+					has_decree = decree_greener_grass_campaign
+				}
+			}
+			random_scope_state = {
+				limit = {
+					region = sr:region_niger
+					has_decree = decree_greener_grass_campaign
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		else = {
+			random_scope_state = {
+				limit = {
+					region = sr:region_niger
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		every_scope_state = {
+			limit = {
+				region = sr:region_niger
+			}
+			set_variable = state_to_cede
+		}
+		create_dynamic_country = {
+			origin = root
+			country_type = colonial
+			tier = principality
+			capital = scope:newly_formed_colonial_nation_capital_scope
+			cede_state_trigger = {
+				has_variable = state_to_cede
+			}
+			on_created = { 
+				set_variable = niger_subject_var
+				set_variable = {
+					name = newly_formed_colonial_nation_var
+					months = 3
+				}
+				every_scope_state = {
+					remove_variable = state_to_cede
+				}
+				activate_law = law_type:law_frontier_colonization
+				activate_law = law_type:law_presidential_republic
+			}
+		}
+		hidden_effect = {
+			create_diplomatic_pact = {
+				country = scope:newly_formed_colonial_nation_capital_scope.owner
+				type = puppet
+			}
+		}
+		trigger_event = { id = colonial_administration_events.1 days = 1 popup = yes }
+		custom_tooltip = je_colonial_administration_button_tt_1
+		custom_tooltip = je_colonial_administration_button_tt_2
+	}
+}
+
+je_colonial_administration_button_ethiopia = {
+	name = "je_colonial_administration_button_ethiopia"
+	desc = "je_colonial_administration_button_ethiopia_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_scope_state = {
+			region = sr:region_ethiopia
+		}
+		NOT = {
+			any_subject_or_below = {
+				has_variable = ethiopia_subject_var
+			}
+		}
+	}
+
+	possible = {
+		any_scope_state = {
+			region = sr:region_ethiopia
+			is_largest_state_in_region = yes
+			count >= 2
+		}
+		custom_tooltip = {
+			text = colonial_administration_cooldown
+			NOT = {
+				any_subject_or_below = {
+					has_variable = newly_formed_colonial_nation_var
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+		modifier = {
+			trigger = {
+				spansen_one_of_us = yes
+			}
+			add = -100
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_ethiopia
+					has_decree = decree_greener_grass_campaign
+				}
+			}
+			random_scope_state = {
+				limit = {
+					region = sr:region_ethiopia
+					has_decree = decree_greener_grass_campaign
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		else = {
+			random_scope_state = {
+				limit = {
+					region = sr:region_ethiopia
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		every_scope_state = {
+			limit = {
+				region = sr:region_ethiopia
+			}
+			set_variable = state_to_cede
+		}
+		create_dynamic_country = {
+			origin = root
+			country_type = colonial
+			tier = principality
+			capital = scope:newly_formed_colonial_nation_capital_scope
+			cede_state_trigger = {
+				has_variable = state_to_cede
+			}
+			on_created = { 
+				set_variable = ethiopia_subject_var
+				set_variable = {
+					name = newly_formed_colonial_nation_var
+					months = 3
+				}
+				every_scope_state = {
+					remove_variable = state_to_cede
+				}
+				activate_law = law_type:law_frontier_colonization
+				activate_law = law_type:law_presidential_republic
+			}
+		}
+		hidden_effect = {
+			create_diplomatic_pact = {
+				country = scope:newly_formed_colonial_nation_capital_scope.owner
+				type = puppet
+			}
+		}
+		trigger_event = { id = colonial_administration_events.1 days = 1 popup = yes }
+		custom_tooltip = je_colonial_administration_button_tt_1
+		custom_tooltip = je_colonial_administration_button_tt_2
+	}
+}
+
+je_colonial_administration_button_zanj = {
+	name = "je_colonial_administration_button_zanj"
+	desc = "je_colonial_administration_button_zanj_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_scope_state = {
+			region = sr:region_zanj
+		}
+		NOT = {
+			any_subject_or_below = {
+				has_variable = zanj_subject_var
+			}
+		}
+	}
+
+	possible = {
+		any_scope_state = {
+			region = sr:region_zanj
+			is_largest_state_in_region = yes
+			count >= 2
+		}
+		custom_tooltip = {
+			text = colonial_administration_cooldown
+			NOT = {
+				any_subject_or_below = {
+					has_variable = newly_formed_colonial_nation_var
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+		modifier = {
+			trigger = {
+				spansen_one_of_us = yes
+			}
+			add = -100
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_zanj
+					has_decree = decree_greener_grass_campaign
+				}
+			}
+			random_scope_state = {
+				limit = {
+					region = sr:region_zanj
+					has_decree = decree_greener_grass_campaign
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		else = {
+			random_scope_state = {
+				limit = {
+					region = sr:region_zanj
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		every_scope_state = {
+			limit = {
+				region = sr:region_zanj
+			}
+			set_variable = state_to_cede
+		}
+		create_dynamic_country = {
+			origin = root
+			country_type = colonial
+			tier = principality
+			capital = scope:newly_formed_colonial_nation_capital_scope
+			cede_state_trigger = {
+				has_variable = state_to_cede
+			}
+			on_created = { 
+				set_variable = zanj_subject_var
+				set_variable = {
+					name = newly_formed_colonial_nation_var
+					months = 3
+				}
+				every_scope_state = {
+					remove_variable = state_to_cede
+				}
+				activate_law = law_type:law_frontier_colonization
+				activate_law = law_type:law_presidential_republic
+			}
+		}
+		hidden_effect = {
+			create_diplomatic_pact = {
+				country = scope:newly_formed_colonial_nation_capital_scope.owner
+				type = puppet
+			}
+		}
+		trigger_event = { id = colonial_administration_events.1 days = 1 popup = yes }
+		custom_tooltip = je_colonial_administration_button_tt_1
+		custom_tooltip = je_colonial_administration_button_tt_2
+	}
+}
+
+je_colonial_administration_button_southern_africa = {
+	name = "je_colonial_administration_button_southern_africa"
+	desc = "je_colonial_administration_button_southern_africa_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_scope_state = {
+			region = sr:region_southern_africa
+		}
+		NOT = {
+			any_subject_or_below = {
+				has_variable = southern_africa_subject_var
+			}
+		}
+	}
+
+	possible = {
+		any_scope_state = {
+			region = sr:region_southern_africa
+			is_largest_state_in_region = yes
+			count >= 2
+		}
+		custom_tooltip = {
+			text = colonial_administration_cooldown
+			NOT = {
+				any_subject_or_below = {
+					has_variable = newly_formed_colonial_nation_var
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+		modifier = {
+			trigger = {
+				spansen_one_of_us = yes
+			}
+			add = -100
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_southern_africa
+					has_decree = decree_greener_grass_campaign
+				}
+			}
+			random_scope_state = {
+				limit = {
+					region = sr:region_southern_africa
+					has_decree = decree_greener_grass_campaign
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		else = {
+			random_scope_state = {
+				limit = {
+					region = sr:region_southern_africa
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		every_scope_state = {
+			limit = {
+				region = sr:region_southern_africa
+			}
+			set_variable = state_to_cede
+		}
+		create_dynamic_country = {
+			origin = root
+			country_type = colonial
+			tier = principality
+			capital = scope:newly_formed_colonial_nation_capital_scope
+			cede_state_trigger = {
+				has_variable = state_to_cede
+			}
+			on_created = { 
+				set_variable = southern_africa_subject_var
+				set_variable = {
+					name = newly_formed_colonial_nation_var
+					months = 3
+				}
+				every_scope_state = {
+					remove_variable = state_to_cede
+				}
+				activate_law = law_type:law_frontier_colonization
+				activate_law = law_type:law_presidential_republic
+			}
+		}
+		hidden_effect = {
+			create_diplomatic_pact = {
+				country = scope:newly_formed_colonial_nation_capital_scope.owner
+				type = puppet
+			}
+		}
+		trigger_event = { id = colonial_administration_events.1 days = 1 popup = yes }
+		custom_tooltip = je_colonial_administration_button_tt_1
+		custom_tooltip = je_colonial_administration_button_tt_2
+	}
+}
+
+je_colonial_administration_button_congo = {
+	name = "je_colonial_administration_button_congo"
+	desc = "je_colonial_administration_button_congo_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_scope_state = {
+			region = sr:region_congo
+		}
+		NOT = {
+			any_subject_or_below = {
+				has_variable = congo_subject_var
+			}
+		}
+	}
+
+	possible = {
+		any_scope_state = {
+			region = sr:region_congo
+			is_largest_state_in_region = yes
+			count >= 2
+		}
+		custom_tooltip = {
+			text = colonial_administration_cooldown
+			NOT = {
+				any_subject_or_below = {
+					has_variable = newly_formed_colonial_nation_var
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+		modifier = {
+			trigger = {
+				spansen_one_of_us = yes
+			}
+			add = -100
+		}
+	}
+
+	effect = {
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_congo
+					has_decree = decree_greener_grass_campaign
+				}
+			}
+			random_scope_state = {
+				limit = {
+					region = sr:region_congo
+					has_decree = decree_greener_grass_campaign
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		else = {
+			random_scope_state = {
+				limit = {
+					region = sr:region_congo
+				}
+				save_scope_as = newly_formed_colonial_nation_capital_scope
+			}
+		}
+		every_scope_state = {
+			limit = {
+				region = sr:region_congo
+			}
+			set_variable = state_to_cede
+		}
+		create_dynamic_country = {
+			origin = root
+			country_type = colonial
+			tier = principality
+			capital = scope:newly_formed_colonial_nation_capital_scope
+			cede_state_trigger = {
+				has_variable = state_to_cede
+			}
+			on_created = { 
+				set_variable = congo_subject_var
+				set_variable = {
+					name = newly_formed_colonial_nation_var
+					months = 3
+				}
+				every_scope_state = {
+					remove_variable = state_to_cede
+				}
+				activate_law = law_type:law_frontier_colonization
+				activate_law = law_type:law_presidential_republic
+			}
+		}
+		hidden_effect = {
+			create_diplomatic_pact = {
+				country = scope:newly_formed_colonial_nation_capital_scope.owner
+				type = puppet
+			}
+		}
+		trigger_event = { id = colonial_administration_events.1 days = 1 popup = yes }
+		custom_tooltip = je_colonial_administration_button_tt_1
+		custom_tooltip = je_colonial_administration_button_tt_2
+	}
+}
+
+
+# Expand Colonial Administration
+
+je_colonial_administration_button_expand_senegal = {
+	name = "je_colonial_administration_button_expand_senegal"
+	desc = "je_colonial_administration_button_expand_senegal_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_subject_or_below = {
+			has_variable = senegal_subject_var
+		}
+	}
+
+	possible = {
+		OR = {
+			any_scope_state = {
+				region = sr:region_senegal
+				is_under_colonization = no
+			}
+			custom_tooltip = {
+				text = colonial_transfer_two_subjects_tt
+				any_subject_or_below = {
+					has_variable = senegal_subject_var
+					count >= 2
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = transfer_stuff_to_subject_tt
+		}
+		random_subject_or_below = {
+			limit = {
+				has_variable = senegal_subject_var
+			}
+			save_scope_as = colonial_transfer_subject_scope
+		}
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_senegal
+					is_under_colonization = no
+				}
+			}
+			every_scope_state = {
+				limit = {
+					region = sr:region_senegal
+					is_under_colonization = no
+				}
+				set_state_owner = scope:colonial_transfer_subject_scope
+			}
+		}
+		if = {
+			limit = {
+				any_subject_or_below = {
+					has_variable = senegal_subject_var
+					count >= 2
+				}
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = senegal_subject_var
+				}
+				save_scope_as = senegal_subject_scope
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = senegal_subject_var
+					NOT = {
+						this = scope:senegal_subject_scope
+					}
+				}
+				save_scope_as = senegal_subject_scope_2
+			}
+			scope:senegal_subject_scope = {
+				annex = scope:senegal_subject_scope_2
+			}
+		}
+	}
+}
+
+je_colonial_administration_button_expand_niger = {
+	name = "je_colonial_administration_button_expand_niger"
+	desc = "je_colonial_administration_button_expand_niger_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_subject_or_below = {
+			has_variable = niger_subject_var
+		}
+	}
+
+	possible = {
+		OR = {
+			any_scope_state = {
+				region = sr:region_niger
+				is_under_colonization = no
+			}
+			custom_tooltip = {
+				text = colonial_transfer_two_subjects_tt
+				any_subject_or_below = {
+					has_variable = niger_subject_var
+					count >= 2
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = transfer_stuff_to_subject_tt
+		}
+		random_subject_or_below = {
+			limit = {
+				has_variable = niger_subject_var
+			}
+			save_scope_as = colonial_transfer_subject_scope
+		}
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_niger
+					is_under_colonization = no
+				}
+			}
+			every_scope_state = {
+				limit = {
+					region = sr:region_niger
+					is_under_colonization = no
+				}
+				set_state_owner = scope:colonial_transfer_subject_scope
+			}
+		}
+		if = {
+			limit = {
+				any_subject_or_below = {
+					has_variable = niger_subject_var
+					count >= 2
+				}
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = niger_subject_var
+				}
+				save_scope_as = niger_subject_scope
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = niger_subject_var
+					NOT = {
+						this = scope:niger_subject_scope
+					}
+				}
+				save_scope_as = niger_subject_scope_2
+			}
+			scope:niger_subject_scope = {
+				annex = scope:niger_subject_scope_2
+			}
+		}
+	}
+}
+
+je_colonial_administration_button_expand_ethiopia = {
+	name = "je_colonial_administration_button_expand_ethiopia"
+	desc = "je_colonial_administration_button_expand_ethiopia_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_subject_or_below = {
+			has_variable = ethiopia_subject_var
+		}
+	}
+
+	possible = {
+		OR = {
+			any_scope_state = {
+				region = sr:region_ethiopia
+				is_under_colonization = no
+			}
+			custom_tooltip = {
+				text = colonial_transfer_two_subjects_tt
+				any_subject_or_below = {
+					has_variable = ethiopia_subject_var
+					count >= 2
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = transfer_stuff_to_subject_tt
+		}
+		random_subject_or_below = {
+			limit = {
+				has_variable = ethiopia_subject_var
+			}
+			save_scope_as = colonial_transfer_subject_scope
+		}
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_ethiopia
+					is_under_colonization = no
+				}
+			}
+			every_scope_state = {
+				limit = {
+					region = sr:region_ethiopia
+					is_under_colonization = no
+				}
+				set_state_owner = scope:colonial_transfer_subject_scope
+			}
+		}
+		if = {
+			limit = {
+				any_subject_or_below = {
+					has_variable = ethiopia_subject_var
+					count >= 2
+				}
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = ethiopia_subject_var
+				}
+				save_scope_as = ethiopia_subject_scope
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = ethiopia_subject_var
+					NOT = {
+						this = scope:ethiopia_subject_scope
+					}
+				}
+				save_scope_as = ethiopia_subject_scope_2
+			}
+			scope:ethiopia_subject_scope = {
+				annex = scope:ethiopia_subject_scope_2
+			}
+		}
+	}
+}
+
+je_colonial_administration_button_expand_zanj = {
+	name = "je_colonial_administration_button_expand_zanj"
+	desc = "je_colonial_administration_button_expand_zanj_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_subject_or_below = {
+			has_variable = zanj_subject_var
+		}
+	}
+
+	possible = {
+		OR = {
+			any_scope_state = {
+				region = sr:region_zanj
+				is_under_colonization = no
+			}
+			custom_tooltip = {
+				text = colonial_transfer_two_subjects_tt
+				any_subject_or_below = {
+					has_variable = zanj_subject_var
+					count >= 2
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = transfer_stuff_to_subject_tt
+		}
+		random_subject_or_below = {
+			limit = {
+				has_variable = zanj_subject_var
+			}
+			save_scope_as = colonial_transfer_subject_scope
+		}
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_zanj
+					is_under_colonization = no
+				}
+			}
+			every_scope_state = {
+				limit = {
+					region = sr:region_zanj
+					is_under_colonization = no
+				}
+				set_state_owner = scope:colonial_transfer_subject_scope
+			}
+		}
+		if = {
+			limit = {
+				any_subject_or_below = {
+					has_variable = zanj_subject_var
+					count >= 2
+				}
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = zanj_subject_var
+				}
+				save_scope_as = zanj_subject_scope
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = zanj_subject_var
+					NOT = {
+						this = scope:zanj_subject_scope
+					}
+				}
+				save_scope_as = zanj_subject_scope_2
+			}
+			scope:zanj_subject_scope = {
+				annex = scope:zanj_subject_scope_2
+			}
+		}
+	}
+}
+
+je_colonial_administration_button_expand_southern_africa = {
+	name = "je_colonial_administration_button_expand_southern_africa"
+	desc = "je_colonial_administration_button_expand_southern_africa_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_subject_or_below = {
+			has_variable = southern_africa_subject_var
+		}
+	}
+
+	possible = {
+		OR = {
+			any_scope_state = {
+				region = sr:region_southern_africa
+				is_under_colonization = no
+			}
+			custom_tooltip = {
+				text = colonial_transfer_two_subjects_tt
+				any_subject_or_below = {
+					has_variable = southern_africa_subject_var
+					count >= 2
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = transfer_stuff_to_subject_tt
+		}
+		random_subject_or_below = {
+			limit = {
+				has_variable = southern_africa_subject_var
+			}
+			save_scope_as = colonial_transfer_subject_scope
+		}
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_southern_africa
+					is_under_colonization = no
+				}
+			}
+			every_scope_state = {
+				limit = {
+					region = sr:region_southern_africa
+					is_under_colonization = no
+				}
+				set_state_owner = scope:colonial_transfer_subject_scope
+			}
+		}
+		if = {
+			limit = {
+				any_subject_or_below = {
+					has_variable = southern_africa_subject_var
+					count >= 2
+				}
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = southern_africa_subject_var
+				}
+				save_scope_as = southern_africa_subject_scope
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = southern_africa_subject_var
+					NOT = {
+						this = scope:southern_africa_subject_scope
+					}
+				}
+				save_scope_as = southern_africa_subject_scope_2
+			}
+			scope:southern_africa_subject_scope = {
+				annex = scope:southern_africa_subject_scope_2
+			}
+		}
+	}
+}
+
+je_colonial_administration_button_expand_congo = {
+	name = "je_colonial_administration_button_expand_congo"
+	desc = "je_colonial_administration_button_expand_congo_desc"
+
+	visible = {
+		country_is_in_africa = no
+		any_subject_or_below = {
+			has_variable = congo_subject_var
+		}
+	}
+
+	possible = {
+		OR = {
+			any_scope_state = {
+				region = sr:region_congo
+				is_under_colonization = no
+			}
+			custom_tooltip = {
+				text = colonial_transfer_two_subjects_tt
+				any_subject_or_below = {
+					has_variable = congo_subject_var
+					count >= 2
+				}
+			}
+		}
+	}
+
+	ai_chance = {
+		base = 100
+	}
+
+	effect = {
+		custom_tooltip = {
+			text = transfer_stuff_to_subject_tt
+		}
+		random_subject_or_below = {
+			limit = {
+				has_variable = congo_subject_var
+			}
+			save_scope_as = colonial_transfer_subject_scope
+		}
+		if = {
+			limit = {
+				any_scope_state = {
+					region = sr:region_congo
+					is_under_colonization = no
+				}
+			}
+			every_scope_state = {
+				limit = {
+					region = sr:region_congo
+					is_under_colonization = no
+				}
+				set_state_owner = scope:colonial_transfer_subject_scope
+			}
+		}
+		if = {
+			limit = {
+				any_subject_or_below = {
+					has_variable = congo_subject_var
+					count >= 2
+				}
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = congo_subject_var
+				}
+				save_scope_as = congo_subject_scope
+			}
+			random_subject_or_below = {
+				limit = {
+					has_variable = congo_subject_var
+					NOT = {
+						this = scope:congo_subject_scope
+					}
+				}
+				save_scope_as = congo_subject_scope_2
+			}
+			scope:congo_subject_scope = {
+				annex = scope:congo_subject_scope_2
+			}
+		}
+	}
+}

--- a/AnnexColonialAdmin/common/scripted_triggers/spansen_st_nations.txt
+++ b/AnnexColonialAdmin/common/scripted_triggers/spansen_st_nations.txt
@@ -1,0 +1,8 @@
+﻿spansen_one_of_us = {
+	OR = {
+		c:SPA ?= this
+		c:AUS ?= this
+		c:PRU ?= this
+		c:PRU ?= this
+	}
+}


### PR DESCRIPTION
stops our MP countries (set in `spansen_st_nations.txt`) from making colonial administrations in the first place (when someone can't make it)